### PR TITLE
fix: update osquery config options to reside in flagfile

### DIFF
--- a/config_files/osquery.conf
+++ b/config_files/osquery.conf
@@ -1,8 +1,5 @@
 {
   "options": {
-    "config_plugin": "filesystem",
-    "logger_plugin": "filesystem",
-    "database_path": "/var/osquery/osquery.db",
     "utc": "true"
   },
 

--- a/config_files/osquery.flags
+++ b/config_files/osquery.flags
@@ -12,3 +12,6 @@
 --logger_rotate=true
 --logger_rotate_size=262144000
 --logger_rotate_max_files=3
+--config_plugin=filesystem
+--logger_plugin=filesystem
+--database_path=/var/osquery/osquery.db


### PR DESCRIPTION
osquery outputs in service status that certain settings must now be configured in the flagfile instead of the config file. This updates the osquery files with the new configuration.

Output from old script service status: ![image](https://user-images.githubusercontent.com/5767516/173905418-f057d838-bf20-4006-8750-6a1d6a3a38a5.png)

Testing: this has been tested on Amazon Linux 2, Ubuntu 20, and Centos 7