### PR TITLE
fix: add os snapshot to osquery

### DIFF
--- a/config_files/osquery.conf
+++ b/config_files/osquery.conf
@@ -42,6 +42,11 @@
       "query": "select address, interface, permanent from arp_cache;",
       "snapshot": true,
       "interval": 300
+    },
+    "os_snapshot" : {
+      "query": "SELECT * FROM os_version;", 
+      "snapshot": true,
+      "interval": 60
     }
   },
   "decorators": {


### PR DESCRIPTION
Add os snapshot to osquery so platforms can be added to servers for grouping