### PR TITLE
fix: remove redundant branch configuration in tests

### DIFF
--- a/.github/workflows/AWS-EC2-Tests.yaml
+++ b/.github/workflows/AWS-EC2-Tests.yaml
@@ -74,6 +74,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.THUNDERDOME_AWS_ROLE }}
           aws-region: ${{ env.TF_VAR_REGION }}
+
       - name: Extract branch name
         shell: bash
         run: echo "THIS_REPO_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_ENV

--- a/.github/workflows/AWS-EC2-Tests.yaml
+++ b/.github/workflows/AWS-EC2-Tests.yaml
@@ -59,7 +59,6 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       INSTALL_BRANCH: main
-      THIS_REPO_BRANCH: main
       TERRAFORM_RUN_DESTROY: true
       FAIL_FIRST_TEST: false
       FAIL_SECOND_TEST: false
@@ -79,7 +78,7 @@ jobs:
         shell: bash
         run: echo "THIS_REPO_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_ENV
         id: extract_branch
-      
+
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/AWS-EC2-Tests.yaml
+++ b/.github/workflows/AWS-EC2-Tests.yaml
@@ -8,10 +8,6 @@ on:
         type: string
         description: Select the branch to test from linux-agent-install-scripts 
         default: main
-      this_repo_branch:
-        type: string
-        description: Select the branch to use from this repo
-        default: main
       terraform_run_destroy:
         type: choice
         options:
@@ -79,15 +75,11 @@ jobs:
         with:
           role-to-assume: ${{ secrets.THUNDERDOME_AWS_ROLE }}
           aws-region: ${{ env.TF_VAR_REGION }}
-
-      - name: Set code repo
-        run: |
-          if ${{ github.event.inputs.this_repo_branch != '' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.event.inputs.this_repo_branch }}" >> $GITHUB_ENV
-          elif ${{ github.event_name == 'pull_request' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.head_ref }}" >> $GITHUB_ENV
-          fi
-          
+      - name: Extract branch name
+        shell: bash
+        run: echo "THIS_REPO_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_ENV
+        id: extract_branch
+      
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/Azure-Compute-Tests.yaml
+++ b/.github/workflows/Azure-Compute-Tests.yaml
@@ -59,7 +59,6 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       INSTALL_BRANCH: main
-      THIS_REPO_BRANCH: main
       TERRAFORM_RUN_DESTROY: true
       FAIL_FIRST_TEST: false
       FAIL_SECOND_TEST: false

--- a/.github/workflows/Azure-Compute-Tests.yaml
+++ b/.github/workflows/Azure-Compute-Tests.yaml
@@ -8,10 +8,6 @@ on:
         type: string
         description: Select the branch to test from linux-agent-install-scripts 
         default: main
-      this_repo_branch:
-        type: string
-        description: Select the branch to use from this repo
-        default: main
       terraform_run_destroy:
         type: choice
         options:
@@ -80,13 +76,10 @@ jobs:
           role-to-assume: ${{ secrets.THUNDERDOME_AWS_ROLE }}
           aws-region: ${{ env.TF_VAR_REGION }}
 
-      - name: Set code repo
-        run: |
-          if ${{ github.event.inputs.this_repo_branch != '' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.event.inputs.this_repo_branch }}" >> $GITHUB_ENV
-          elif ${{ github.event_name == 'pull_request' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.head_ref }}" >> $GITHUB_ENV
-          fi
+      - name: Extract branch name
+        shell: bash
+        run: echo "THIS_REPO_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_ENV
+        id: extract_branch
 
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/GCP-Compute-Tests.yaml
+++ b/.github/workflows/GCP-Compute-Tests.yaml
@@ -56,7 +56,6 @@ jobs:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
 
       INSTALL_BRANCH: main
-      THIS_REPO_BRANCH: main
       TERRAFORM_RUN_DESTROY: true
       FAIL_FIRST_TEST: false
       FAIL_SECOND_TEST: false

--- a/.github/workflows/GCP-Compute-Tests.yaml
+++ b/.github/workflows/GCP-Compute-Tests.yaml
@@ -8,10 +8,6 @@ on:
         type: string
         description: Select the branch to test from linux-agent-install-scripts 
         default: main
-      this_repo_branch:
-        type: string
-        description: Select the branch to use from this repo
-        default: main
       terraform_run_destroy:
         type: choice
         options:
@@ -77,13 +73,10 @@ jobs:
           role-to-assume: ${{ secrets.THUNDERDOME_AWS_ROLE }}
           aws-region: ${{ env.TF_VAR_REGION }}
 
-      - name: Set code repo
-        run: |
-          if ${{ github.event.inputs.this_repo_branch != '' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.event.inputs.this_repo_branch }}" >> $GITHUB_ENV
-          elif ${{ github.event_name == 'pull_request' }}; then
-            echo "THIS_REPO_BRANCH=refs/heads/${{ github.head_ref }}" >> $GITHUB_ENV
-          fi
+      - name: Extract branch name
+        shell: bash
+        run: echo "THIS_REPO_BRANCH=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_ENV
+        id: extract_branch
 
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/test_code/python_scripts/workflow_tasks.py
+++ b/test_code/python_scripts/workflow_tasks.py
@@ -170,7 +170,6 @@ def set_custom_vars(context_dir="context", local_test=False):
             if event_name == "workflow_dispatch":
                 inputs = git_hub_context_data["event"]["inputs"]
                 install_script_branch = inputs["install_script_branch"]
-                this_repo_branch = inputs["this_repo_branch"]
                 terraform_run_destroy = inputs["terraform_run_destroy"]
                 fail_first_test = inputs["fail_first_test"]
                 fail_second_test = inputs["fail_second_test"]
@@ -180,7 +179,6 @@ def set_custom_vars(context_dir="context", local_test=False):
 
                 print(seperator)
                 print(f"install_script_branch={install_script_branch}")
-                print(f"this_repo_branch={this_repo_branch}")
                 print(f"terraform_run_destroy={terraform_run_destroy}")
                 print(f"fail_first_test={fail_first_test}")
                 print(f"fail_second_test={fail_second_test}")
@@ -190,7 +188,6 @@ def set_custom_vars(context_dir="context", local_test=False):
                 environmentFile.write(
                     f"TF_VAR_USE_BRANCH_NAME={install_script_branch}\n"
                 )
-                environmentFile.write(f"THIS_REPO_BRANCH={this_repo_branch}\n")
 
                 environmentFile.write(
                     f"TERRAFORM_RUN_DESTROY={terraform_run_destroy}\n"
@@ -202,7 +199,6 @@ def set_custom_vars(context_dir="context", local_test=False):
             if event_name == "pull_request":
                 # ref = git_hub_context_data["head_ref"]
                 environmentFile.write(f"TERRAFORM_RUN_DESTROY=false\n")
-                # environmentFile.write(f"THIS_REPO_BRANCH={head_ref}\n")
 
             # value for resource names
             environmentFile.write(


### PR DESCRIPTION
Removes the variable where branch is manually input, utilizes GitHub's branch selector instead

Successful runs utilizing not-main branch and the changes present in this PR: 

* [AWS](https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/4514762514/jobs/7951300765)
* [Azure](https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/4514818298/jobs/7951357748)
* [GCP](https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/4514975223/jobs/7951731206)