### PR TITLE
feat: add windows testing tf + python

### DIFF
--- a/.github/workflows/AWS-EC2-Tests.yaml
+++ b/.github/workflows/AWS-EC2-Tests.yaml
@@ -8,6 +8,10 @@ on:
         type: string
         description: Select the branch to use from this repo
         default: main
+      windows_repo_branch:
+        type: string
+        description: Select the branch to use from windows-host-configuration repo
+        default: main
       terraform_run_destroy:
         type: choice
         options:
@@ -51,6 +55,7 @@ jobs:
     env:
       TF_VAR_REGION: "us-west-2"
       THIS_REPO_BRANCH: main
+      WINDOWS_REPO_BRANCH: main
       TERRAFORM_RUN_DESTROY: true
       FAIL_FIRST_TEST: false
       FAIL_SECOND_TEST: false
@@ -90,12 +95,14 @@ jobs:
           role-to-assume: ${{ steps.secrets.outputs.THUNDERDOME_AWS_ROLE }}
           aws-region: ${{ env.TF_VAR_REGION }}
 
-      - name: Set code repo
-        run: |
-          if ${{ github.event.inputs.this_repo_branch != '' }}; then
+      - name: Set code repo #Set branches based on via Workflow Dispatch or Pull Request 
+        run: | 
+          if ${{ github.event.inputs.this_repo_branch != '' }}; then  
             echo "THIS_REPO_BRANCH=refs/heads/${{ github.event.inputs.this_repo_branch }}" >> $GITHUB_ENV
+            echo "WINDOWS_REPO_BRANCH=refs/heads/${{ github.event.inputs.windows_repo_branch }}" >> $GITHUB_ENV
           elif ${{ github.event_name == 'pull_request' }}; then
             echo "THIS_REPO_BRANCH=refs/heads/${{ github.head_ref }}" >> $GITHUB_ENV
+            echo "WINDOWS_REPO_BRANCH=refs/heads/${{ env.WINDOWS_REPO_BRANCH}}" >> $GITHUB_ENV
           fi
 
       - name: Set env var
@@ -106,7 +113,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.THIS_REPO_BRANCH }}
-
+    
       - name: Set contexts
         run: |
           mkdir context 
@@ -165,14 +172,14 @@ jobs:
           pip3 install -r requirements.txt
 
           # run tests 
-          fab test -a ${{ env.FAIL_FIRST_TEST }} -b ${{ env.THIS_REPO_BRANCH }} -o "1: run fabric tests python script"
+          fab test -a ${{ env.FAIL_FIRST_TEST }} -b ${{ env.THIS_REPO_BRANCH }} -w ${{ env.WINDOWS_REPO_BRANCH }} -o "1: run fabric tests python script"
         working-directory: "${{ env.WORK_DIR }}/python_scripts"
 
       - name: Retry tests
         if: ${{ env.TEST_RESULT == 'FAIL' }} 
         run: |
           # run tests
-          fab test -a ${{ env.FAIL_SECOND_TEST }} -o "2: Retry tests"  -b ${{ env.THIS_REPO_BRANCH }}
+          fab test -a ${{ env.FAIL_SECOND_TEST }} -o "2: Retry tests" -w ${{ env.WINDOWS_REPO_BRANCH }} -b ${{ env.THIS_REPO_BRANCH }}
           
         working-directory: "${{ env.WORK_DIR }}/python_scripts" 
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ __pycache__
 test_code/python_scripts/testenv
 log_outputs
 /test_code/python_scripts/context
+/test_code/python_scripts/.idea
 /test_code/outputs.tf

--- a/test_code/AWS_MACHINES/data.tf
+++ b/test_code/AWS_MACHINES/data.tf
@@ -1,24 +1,3 @@
-# This gets your local machine ip for use in security group 
-# data "http" "myip" {
-#   url = "https://ipv4.icanhazip.com/?4"
-# }
-
-# Use a pre-deployed vpc - this is where ec2 instance will be deployed
-data "aws_vpc" "main" {
-  default = false
-  tags = {
-    Name = "linux-host-test-vpc"
-  }
-}
-
-data "aws_subnet" "main" {
-  vpc_id = data.aws_vpc.main.id
-  filter {
-    name   = "tag:Name"
-    values = ["linux-host-test-subnet"]
-  }
-}
-
 # The Canonical User ID data source allows access to the canonical user ID for the effective account in which Terraform is working.
 # tflint-ignore: terraform_unused_declarations
 data "aws_canonical_user_id" "current_user" {

--- a/test_code/AWS_MACHINES/main.tf
+++ b/test_code/AWS_MACHINES/main.tf
@@ -33,12 +33,13 @@ resource "aws_instance" "linux_host_integration" {
 
   associate_public_ip_address = true
 
-  subnet_id = data.aws_subnet.main.id
+  subnet_id = aws_subnet.subnet_public.id 
 
   vpc_security_group_ids = [aws_security_group.ec2_public.id]
   key_name               = aws_key_pair.ec2key.key_name
 
   user_data = file(each.value.user_data)
+  get_password_data = can(regex("WINDOWS", each.key)) ? true : false
 
   root_block_device {
     volume_size = 30

--- a/test_code/AWS_MACHINES/networking.tf
+++ b/test_code/AWS_MACHINES/networking.tf
@@ -1,0 +1,52 @@
+#Create VPC 
+resource "aws_vpc" "vpc_public" {
+  cidr_block       = "10.0.0.0/16"
+  enable_dns_hostnames = "true"
+  tags = merge(
+    var.BASE_TAGS,
+    { Name = format(var.name_format, "vpc") },
+  )
+}
+
+# Creating Internet Gateway attached to VPC 
+resource "aws_internet_gateway" "gateway_public" { 
+  vpc_id   = aws_vpc.vpc_public.id            # vpc_id will be generated after we create VPC
+  tags = merge(
+    var.BASE_TAGS,
+    { Name = format(var.name_format, "gateway") }
+  )
+}
+
+#Create public subnet within our VPC
+resource "aws_subnet" "subnet_public" {
+  vpc_id     = aws_vpc.vpc_public.id
+  cidr_block = "10.0.0.0/24"
+
+  tags = merge(
+    var.BASE_TAGS,
+    { Name = format(var.name_format, "subnet") }
+  )
+}
+
+#Create route table on our VPC 
+resource "aws_route_table" "rt_public" {
+  vpc_id = aws_vpc.vpc_public.id 
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gateway_public.id
+  }
+
+
+  tags = merge(
+    var.BASE_TAGS,
+    { Name = format(var.name_format, "route-table") }
+  )
+}
+
+
+#Associate Public subnet with abve Route Table 
+resource "aws_route_table_association" "rt_public_to_subnet" {
+  subnet_id      = aws_subnet.subnet_public.id
+  route_table_id = aws_route_table.rt_public.id 
+}

--- a/test_code/AWS_MACHINES/outputs.tf
+++ b/test_code/AWS_MACHINES/outputs.tf
@@ -21,6 +21,7 @@ output "fab_hosts" {
       "user" = var.AWS_MACHINE_CONFIGS[key].default_user
       "connect_kwargs" = {
         "key_filename" : var.PRIVATE_KEY_PATH
+        "password" = can(regex("WINDOWS", key)) ? rsadecrypt(value.password_data, file(var.PRIVATE_KEY_PATH)) : null     
       }
       "public_ssh_link" = "ssh -i ${var.PRIVATE_KEY_PATH} ${var.AWS_MACHINE_CONFIGS[key].default_user}@${value.public_ip}"
       "sleep" : var.AWS_MACHINE_CONFIGS[key].sleep

--- a/test_code/AWS_MACHINES/security_group.tf
+++ b/test_code/AWS_MACHINES/security_group.tf
@@ -1,12 +1,21 @@
 resource "aws_security_group" "ec2_public" {
   name   = format(var.name_format, "ec2_sg")
-  vpc_id = data.aws_vpc.main.id
+  vpc_id = aws_vpc.vpc_public.id  
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow incomming SSH connections"
   }
+
+   ingress {
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow incoming RDP connections"
+  }  
   egress {
     from_port   = 0
     to_port     = 0

--- a/test_code/AWS_MACHINES/variables.tf
+++ b/test_code/AWS_MACHINES/variables.tf
@@ -105,7 +105,7 @@ variable "AWS_MACHINE_CONFIGS" {
       ami_description   = "Amazon Linux 2 Kernel 5.10 AMI 2.0.20220419.0 x86_64 HVM gp2"
       default_user      = "ec2-user"
       sleep             = 60
-      user_data         = "user_data/aptbased.sh"
+      user_data         = "user_data/yumbased.sh"
     }
 
     AMAZON_LINUX_2023 = {
@@ -114,7 +114,7 @@ variable "AWS_MACHINE_CONFIGS" {
       ami_description   = "Amazon Linux 2023 AMI 2023.0.20230322.0 x86_64 HVM kernel-6.1"
       default_user      = "ec2-user"
       sleep             = 60
-      user_data         = "user_data/aptbased.sh"
+      user_data         = "user_data/yumbased.sh"
     }
 
     RHEL_8_4_0 = {
@@ -135,6 +135,35 @@ variable "AWS_MACHINE_CONFIGS" {
       sleep             = 120
       user_data         = "user_data/yumbased.sh"
     }
+
+    WINDOWS_SERVER_2016_BASE = {
+      ami_instance_type = "t3.small"
+      ami_id            = "ami-0d7c5eb6a3508d55c"
+      ami_description   = "Microsoft Windows Server 2016 with Desktop Experience Locale English AMI provided by Amazon"
+      default_user      = "Administrator"
+      sleep             = 120
+      user_data         = "user_data/windows.ps"
+    }  
+
+    WINDOWS_SERVER_2019_BASE = {
+      ami_instance_type = "t3.small"
+      ami_id            = "ami-05ca24eaec19902c1"
+      ami_description   = "Microsoft Windows Server 2019 with Desktop Experience Locale English AMI provided by Amazon"
+      default_user      = "Administrator"
+      sleep             = 120
+      user_data         = "user_data/windows.ps"
+    }  
+    
+    WINDOWS_SERVER_2022_BASE = {
+      ami_instance_type = "t3.small"
+      ami_id            = "ami-06810ab448caa0133"
+      ami_description   = "Microsoft Windows Server 2022 Full Locale English AMI provided by Amazon"
+      default_user      = "Administrator"
+      sleep             = 120
+      user_data         = "user_data/windows.ps"
+    }  
+
+    
   }
 }
 

--- a/test_code/python_scripts/fabric_debug.py
+++ b/test_code/python_scripts/fabric_debug.py
@@ -1,0 +1,4 @@
+import fabric.main
+
+if __name__ == '__main__':
+    fabric.main.program.run('fab test --runTerraformOutput=true -s 0 --branch main --windowsBranch main --log-level DEBUG')

--- a/test_code/python_scripts/workflow_tasks.py
+++ b/test_code/python_scripts/workflow_tasks.py
@@ -114,6 +114,7 @@ def tf_output_file(module="", output_file_path="../outputs.tf"):
             f"""
             output "fab_host_all" {{
                 value = module.{module}.fab_hosts
+                sensitive = true 
                 }}
             """
         )

--- a/test_code/user_data/windows.ps
+++ b/test_code/user_data/windows.ps
@@ -1,0 +1,36 @@
+<powershell>
+# Execute it with elevated permissions
+# Description: 
+# This script install automatically the open-ssh feature and enable it
+
+# enable tls1.2 for downloads
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# creating openssh folder and download the zip
+mkdir c:\openssh-install 
+cd c:\openssh-install
+
+#update the last version if you want the last release
+Invoke-WebRequest -Uri "https://github.com/PowerShell/Win32-OpenSSH/releases/download/V8.6.0.0p1-Beta/OpenSSH-Win64.zip" -OutFile .\openssh.zip
+Expand-Archive .\openssh.zip -DestinationPath .\openssh\
+cd .\openssh\OpenSSH-Win64\
+
+# required for enable the service
+setx PATH "$env:path;c:\openssh-install\openssh\OpenSSH-Win64\" -m
+
+# required for install the service
+powershell.exe -ExecutionPolicy Bypass -File install-sshd.ps1
+
+# required for execute remote connections
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+
+net start sshd
+
+# auto enable for each restart machine
+Set-Service sshd -StartupType Automatic
+
+#Set default shell to powershell
+New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+
+</powershell>
+<persist>true</persist>


### PR DESCRIPTION
**Description:**

Addresses: https://observe.atlassian.net/browse/CON-1395 

- Updates AWS EC2 only (Azure/GCP will be different ticket) to include Windows Server 2016, 2019, 2022
- Updates EC2 to include / decode / output password data for Windows  (passwords are sensitive and masked in python test code as well)
- Updates AWS Stack to include `networking.tf` allowing creation of vpc, subnet, gateway, route tables (to prevent relying on data sources) --> Thunderdome will kill resources so this is necessary 
- Updates python test scripts to support windows testing
- Adds powershell startup scripts (tested across all servers) to enable PS / SSH control 

**Testing**:
- See GH Actions run as part of this PR  and outcome (https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/5765405161)  
- Extensive TF + Local Python testing 
- Note to test windows_branch in https://github.com/observeinc/windows-host-configuration-scripts, feed in the `windows_repo_branch` var and it'll use that branch to generate the appropriate windows curl command

<img width="670" alt="Screenshot 2023-08-04 at 1 50 13 PM" src="https://github.com/observeinc/linux-host-configuration-scripts/assets/124205220/b3f9855c-fc03-4b77-9acf-0627ff10df8b">




