### PR TITLE
feat: add VMs to Observe validation for AWS,GCP,Azure

### DIFF
--- a/.github/workflows/AWS-EC2-Tests.yaml
+++ b/.github/workflows/AWS-EC2-Tests.yaml
@@ -87,6 +87,10 @@ jobs:
             STAGE_CUSTOMER_ID:projects/896946759488/secrets/STAGE_CUSTOMER_ID
             STAGE_DATASTREAM_TOKEN:projects/896946759488/secrets/STAGE_DATASTREAM_TOKEN
             STAGE_DOMAIN:projects/896946759488/secrets/STAGE_DOMAIN
+            STAGE_USER_EMAIL:projects/896946759488/secrets/STAGE_USER_EMAIL
+            STAGE_USER_PASSWORD:projects/896946759488/secrets/STAGE_USER_PASSWORD
+
+
 
       # AWS Login - orig role - has to occur before checkout
       - name: Configure AWS Credentials
@@ -134,7 +138,7 @@ jobs:
 
           python3 -c "from workflow_tasks import tf_output_file; tf_output_file(module=\"${{ env.MODULE }}\")"
 
-          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\")"
+          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\",user_email=\"${{ steps.secrets.outputs.STAGE_USER_EMAIL }}\",user_password=\"${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}\")"
 
         working-directory: "${{ env.WORK_DIR }}/python_scripts"
 
@@ -167,7 +171,7 @@ jobs:
           # create output directory for archive files
           mkdir file_outputs
           mkdir log_outputs
-
+          
           # install dependencies
           pip3 install -r requirements.txt
 
@@ -190,9 +194,14 @@ jobs:
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/file_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL}}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD}}/******/g' ./python_scripts/file_outputs/*
+
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/log_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/log_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL }}/******/g' ./python_scripts/log_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}/******/g' ./python_scripts/log_outputs/*
 
         working-directory: "${{ env.WORK_DIR }}"
 

--- a/.github/workflows/Azure-Compute-Tests.yaml
+++ b/.github/workflows/Azure-Compute-Tests.yaml
@@ -87,6 +87,8 @@ jobs:
             ARM_CLIENT_SECRET:content-eng-linux-host-test/ARM_CLIENT_SECRET
             ARM_SUBSCRIPTION_ID:content-eng-linux-host-test/ARM_SUBSCRIPTION_ID
             ARM_TENANT_ID:content-eng-linux-host-test/ARM_TENANT_ID
+            STAGE_USER_EMAIL:content-eng-linux-host-test/STAGE_USER_EMAIL
+            STAGE_USER_PASSWORD:content-eng-linux-host-test/STAGE_USER_PASSWORD
 
       # AWS Login - orig role - has to occur before checkout
       - name: Configure AWS Credentials
@@ -136,7 +138,7 @@ jobs:
 
           python3 -c "from workflow_tasks import tf_output_file; tf_output_file(module=\"${{ env.MODULE }}\")"
 
-          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\")"
+          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\",user_email=\"${{ steps.secrets.outputs.STAGE_USER_EMAIL }}\",user_password=\"${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}\")"
 
         working-directory: "${{ env.WORK_DIR }}/python_scripts"
 
@@ -192,10 +194,14 @@ jobs:
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/file_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL}}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD}}/******/g' ./python_scripts/file_outputs/*
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/log_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/log_outputs/*
-
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL }}/******/g' ./python_scripts/log_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}/******/g' ./python_scripts/log_outputs/*
+          
         working-directory: "${{ env.WORK_DIR }}"
 
       - name: Archive test results

--- a/.github/workflows/GCP-Compute-Tests.yaml
+++ b/.github/workflows/GCP-Compute-Tests.yaml
@@ -84,6 +84,8 @@ jobs:
             STAGE_CUSTOMER_ID:content-eng-linux-host-test/STAGE_CUSTOMER_ID
             STAGE_DATASTREAM_TOKEN:content-eng-linux-host-test/STAGE_DATASTREAM_TOKEN
             STAGE_DOMAIN:content-eng-linux-host-test/STAGE_DOMAIN
+            STAGE_USER_EMAIL:content-eng-linux-host-test/STAGE_USER_EMAIL
+            STAGE_USER_PASSWORD:content-eng-linux-host-test/STAGE_USER_PASSWORD
             
       # AWS Login - orig role - has to occur before checkout
       - name: Configure AWS Credentials
@@ -141,8 +143,7 @@ jobs:
 
           python3 -c "from workflow_tasks import tf_output_file; tf_output_file(module=\"${{ env.MODULE }}\")"
 
-          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\")"
-
+          python3 -c "from workflow_tasks import config_ini; config_ini(custid=\"${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}\", domain=\"${{ steps.secrets.outputs.STAGE_DOMAIN }}\", token=\"${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}\",user_email=\"${{ steps.secrets.outputs.STAGE_USER_EMAIL }}\",user_password=\"${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}\")"
         working-directory: "${{ env.WORK_DIR }}/python_scripts"
 
       - name: Print Environment Variables - troubleshooting
@@ -197,10 +198,14 @@ jobs:
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/file_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL}}/******/g' ./python_scripts/file_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD}}/******/g' ./python_scripts/file_outputs/*
 
           sed -i 's/${{ steps.secrets.outputs.STAGE_DATASTREAM_TOKEN }}/******/g' ./python_scripts/log_outputs/*
           sed -i 's/${{ steps.secrets.outputs.STAGE_CUSTOMER_ID }}/******/g' ./python_scripts/log_outputs/*
-
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_EMAIL }}/******/g' ./python_scripts/log_outputs/*
+          sed -i 's/${{ steps.secrets.outputs.STAGE_USER_PASSWORD }}/******/g' ./python_scripts/log_outputs/*
+          
         working-directory: "${{ env.WORK_DIR }}"
 
       - name: Archive test results

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 override.tf
 *.tfvars
 .terraform*
+terraform.tfstate
+terraform.tfstate.backup
 tf_hosts.json
 __pycache__
 /test_code/python_scripts/file_outputs

--- a/test_code/AWS_MACHINES/outputs.tf
+++ b/test_code/AWS_MACHINES/outputs.tf
@@ -17,7 +17,8 @@ output "ec2" {
 output "fab_hosts" {
   value = { for key, value in aws_instance.linux_host_integration :
     "AWS_${key}" => {
-      "host" = value.public_ip
+      "host"            = value.public_ip
+      "instance_id"     = value.id
       "user" = var.AWS_MACHINE_CONFIGS[key].default_user
       "connect_kwargs" = {
         "key_filename" : var.PRIVATE_KEY_PATH

--- a/test_code/AZURE_MACHINES/outputs.tf
+++ b/test_code/AZURE_MACHINES/outputs.tf
@@ -2,6 +2,7 @@ output "fab_hosts" {
   value = { for key, value in azurerm_linux_virtual_machine.linux_host_test :
     "AZURE_${key}" => {
       "host" = value.public_ip_address
+      "name" = value.name
       "user" = var.AZURE_MACHINE_CONFIGS[key].default_user
       "connect_kwargs" = {
         "key_filename" : var.PRIVATE_KEY_PATH

--- a/test_code/GCP_MACHINES/outputs.tf
+++ b/test_code/GCP_MACHINES/outputs.tf
@@ -2,6 +2,7 @@ output "fab_hosts" {
   value = { for key, value in google_compute_instance.instances :
     "GCP_${key}" => {
       "host" = value.network_interface[0].access_config[0].nat_ip
+      "name" = value.name
       "user" = var.GCP_MACHINE_CONFIGS[key].default_user
       "connect_kwargs" = {
         "key_filename" : var.PRIVATE_KEY_PATH

--- a/test_code/python_scripts/README.md
+++ b/test_code/python_scripts/README.md
@@ -36,11 +36,14 @@ mkdir log_outputs
 
 ### create config.ini 
 You need to create a file with customer id and token for observe dataset for sending data
+Additionally you will need to add user_email and user_password to valid data in Observe that is being sent. 
 
 [target-stage-tenant]
 customer_id = 155575265738
 domain = observe-staging
 datastream_token = YOURS
+user_email = YOURS
+user_password = YOURS
 ### Run tests
 Run ```fab test -h ``` for options
 

--- a/test_code/python_scripts/requirements.txt
+++ b/test_code/python_scripts/requirements.txt
@@ -1,11 +1,17 @@
 bcrypt==4.0.1
+certifi==2023.7.22
 cffi==1.15.1
+charset-normalizer==3.2.0
 configparser==5.3.0
 cryptography==38.0.4
+decorator==5.1.1
 fabric==2.7.1
+idna==3.4
 invoke==1.7.3
 paramiko==2.12.0
 pathlib2==2.3.7.post1
 pycparser==2.21
 PyNaCl==1.5.0
+requests==2.31.0
 six==1.16.0
+urllib3==2.0.4

--- a/test_code/python_scripts/validate_observe.py
+++ b/test_code/python_scripts/validate_observe.py
@@ -1,0 +1,280 @@
+import configparser
+import json
+import re
+import logging
+import requests
+import os, sys
+import pprint
+
+
+ENVIRONMENT = 'target-stage-tenant'
+
+# Set up the logger instance
+logger = logging.getLogger(__name__)
+
+
+def getObserveConfig(config: str, environment: str) -> str:
+    """Fetches config file
+    @param config:
+    @param environment:
+    @return: config element
+    """
+
+    # Set your Observe environment details in config\configfile.ini
+    configuration = configparser.ConfigParser()
+    configuration.read("config.ini")
+    observe_configuration = configuration[environment]
+
+    return observe_configuration[config]
+
+
+def get_bearer_token() -> str:
+    """Logins into account and gets bearer token
+    @return: bearer_token
+    """
+
+    customer_id = getObserveConfig("customer_id", ENVIRONMENT)
+    domain = getObserveConfig("domain", ENVIRONMENT)
+    user_email = getObserveConfig("user_email", ENVIRONMENT)
+    user_password = getObserveConfig("user_password", ENVIRONMENT)
+
+    url = f"https://{customer_id}.{domain}.com/v1/login"
+
+    message = '{"user_email":"$user_email$","user_password":"$user_password$"}'
+    tokens_to_replace = {
+        "$user_email$": user_email,
+        "$user_password$": user_password,
+    }
+    for key, value in tokens_to_replace.items():
+        message = message.replace(key, value)
+
+    header = {
+        "Content-Type": "application/json",
+    }
+
+    response = json.loads(
+        requests.post(url, data=message, headers=header, timeout=10).text
+    )
+    bearer_token = response['access_key']
+    return bearer_token
+
+
+def send_query(bearer_token: str, query: str, url_extension: str = '', type='gql') -> list or object:
+    """
+
+    @param bearer_token: generated from credentials
+    @param query: graphQL query
+    @return: response of graphQL query
+    """
+    customer_id = getObserveConfig("customer_id", ENVIRONMENT)
+    domain = getObserveConfig("domain", ENVIRONMENT)
+
+    # Set the GraphQL API endpoint URL
+    url = f"https://{customer_id}.{domain}.com/v1/meta{url_extension}"
+
+    # Set the headers (including authentication)
+    headers = {
+        "Authorization": f"""Bearer {customer_id} {bearer_token}""",
+        'Content-Type': 'application/json',
+        'Accept': 'application/x-ndjson'
+    }
+
+    # Create the request payload for GQL/OpenAPI
+    if type == 'gql':
+        data = {
+            'query': query
+        }
+    elif type == 'openapi':
+        data = json.loads(query)
+    else:
+        data = {None}
+    # Send the POST request
+    try:
+        response = requests.post(url, json=data, headers=headers)
+        response.raise_for_status()
+        # result = response.json() #TODO json object is per line with new line delimiteres for openpi
+        if type == 'gql':
+            result = response.json()
+            logger.debug("Request for query {} successful with status code {}:".format(query, response.status_code))
+            logger.debug("Response:{}".format(result))
+            return result
+        else:
+            result = response.text
+            json_objects = result.strip().split('\n')
+            json_list = []
+            if json_objects:
+                for obj in json_objects:
+                    json_list.append(json.loads(obj))
+            logger.debug("Request for query {} successful with status code {}:".format(query, response.status_code))
+            logger.debug("Response:{}".format(json_list))
+            return json_list
+    except requests.exceptions.HTTPError as err:
+        logging.debug(err.request.url)
+        logging.debug(err)
+        logging.debug(err.response.text)
+        return None
+
+def search_dataset_id(bearer_token: str, dataset_name: str) -> str:
+    """Uses Bearer token and dataset_name to return dataset_id
+    dataset_id is used to query a dataset
+    @param bearer_token: token for querying
+    @param dataset_name: dataset name for which to find its id eg: "Server/OSQuery Events"
+    @return:
+    """
+
+    query = """    
+    query {
+        datasetSearch(labelMatches: "%s"){
+            dataset{
+                id
+                name
+            }
+        }
+    }
+    """ % (dataset_name)
+
+    response = send_query(bearer_token, query, type='gql')
+
+    dataset_id = response["data"]["datasetSearch"][0]["dataset"]["id"]
+    logging.debug("Dataset Name: {} <-->  Dataset ID: {}".format(dataset_name, dataset_id))
+
+    return dataset_id
+
+
+def query_dataset(bearer_token: str, dataset_id: str, pipeline: str = "", interval: str = "30m") -> list:
+    """
+
+    Queries the last 30 minutes (default) of a dataset returning result of query. Uses Observe OpenAPI
+
+    @param bearer_token: bearer token for authorization
+    @param dataset_id: dataset_id to query using openAPI query
+    @param pipeline: OPAL Pipeline
+
+    @return: dataset: queried dataset  in json separated by timestamps
+
+    See  https://developer.observeinc.com/#/paths/~1v1~1meta~1export~1query/post
+    """
+    logger.info("Querying Dataset for Dataset ID: {}".format(dataset_id))
+    query = """
+     {
+        "query": {
+            "stages":[
+              {
+                 "input":[
+                     {
+                     "inputName": "default",
+                     "datasetId": "%s"
+                    }
+                ],
+                "stageID":"main",
+                "pipeline": "%s"
+            }
+        ]
+      },
+
+      "interval" : "%s"
+      
+    }
+    """ % (dataset_id, pipeline, interval)
+    dataset = send_query(bearer_token, query, url_extension='/export/query', type='openapi')
+    return dataset
+
+
+def is_instance_present(instance_id: str, query: list) -> bool:
+    """
+    Check if an instance with the given instance ID (in gcp, aws, azure) is present in the query results.
+    instance_id comes from tf_hosts.json which is the output of tf output fab_host_all command
+
+    @param instance_id: string of type <i-0abc123>
+    @param query: list containing output of OPAL query via open API
+    @return: True if an EC2 instance with the specified instance ID is found, False otherwise.
+    """
+    instance_id_found = any(item.get('instance_id') == instance_id for item in query)
+    name = next((item.get('name') for item in query if 'name' in item), None)
+
+    if instance_id_found:
+        logger.info(f"Instance ID {instance_id} is present in the {name} query.")
+        return True
+    else:
+        logger.info(f"Instance ID {instance_id} is NOT present in the {name} query.")
+        return False
+
+
+def validate_in_observe(instance_id: str, type: str, cloud: str) -> bool:
+    """
+    Validate in Observe whether an Instance is present in Events of type <>
+
+    @param instance_id: takes instance_id (gcp,aws,azure) and validate whether in Observe Host Monitoring <i-123abc..>
+    @param type: can be fluentbit, telegraf, osquery events in Host Monitoring
+    @param cloud: can be aws, azure, gcp, use for generating correct OPAL to query
+    @return True if instance_id present in type event, False if not present in type event
+    """
+    logger.info("Starting Validation for instance_id {} of type {} in cloud {}".format(instance_id, type, cloud))
+    logging.getLogger().setLevel(logging.INFO)
+
+    if cloud =='aws':
+        fluentbit_pipeline = "make_col instance_id:string(event.ec2_instance_id)|make_col " \
+                             "name:'fluentbit_events'|timechart options(bins: 1), " \
+                             "count: count_distinct_exact(1), group_by(instance_id,name)"
+
+        telegraf_pipeline = "make_col instance_id:string(tags.instanceId)|make_col name:'telegraf_events'|timechart " \
+                            "options(bins: 1), count: count_distinct_exact(1), group_by(instance_id, name)"
+
+        osquery_pipeline = "make_col instance_id:string(tags.ec2_instance_id)|make_col " \
+                           "name:'osquery_events'|timechart options(bins: 1), " \
+                           "count: count_distinct_exact(1), group_by(instance_id,name)"
+
+
+    if cloud =='gcp':
+        fluentbit_pipeline = "make_col instance_id:string(tags.host)|make_col " \
+                             "name:'fluentbit_events'|timechart options(bins: 1), " \
+                             "count: count_distinct_exact(1), group_by(instance_id,name)"
+
+        telegraf_pipeline = "make_col instance_id:string(tags.host)|make_col name:'telegraf_events'|timechart " \
+                            "options(bins: 1), count: count_distinct_exact(1), group_by(instance_id, name)"
+
+        osquery_pipeline = "make_col instance_id:string(tags.host)|make_col " \
+                           "name:'osquery_events'|timechart options(bins: 1), " \
+                           "count: count_distinct_exact(1), group_by(instance_id,name)"
+    if cloud == 'azure':
+        fluentbit_pipeline = "make_col instance_id:string(tags.host)|make_col " \
+                             "name:'fluentbit_events'|make_col datacenter:string(tags.datacenter)|filter datacenter = " \
+                             "'AZURE'|timechart options(bins: 1), " \
+                             "count: count_distinct_exact(1), group_by(instance_id,name)"
+
+        telegraf_pipeline = "make_col instance_id:string(tags.host)|make_col name:'telegraf_events'|make_col " \
+                            "datacenter:string(tags.datacenter)|filter datacenter = 'AZURE'|timechart " \
+                            "options(bins: 1), count: count_distinct_exact(1), group_by(instance_id, name)"
+
+        osquery_pipeline = "make_col instance_id:string(tags.host)|make_col " \
+                           "name:'osquery_events'|make_col datacenter:string(tags.datacenter)|filter datacenter = " \
+                           "'AZURE'|timechart options(bins: " \
+                           "1), " \
+                           "count: count_distinct_exact(1), group_by(instance_id,name)"
+
+
+
+    bearer_token = get_bearer_token()
+
+    if type == 'fluentbit':
+        dataset_id = search_dataset_id(bearer_token, "Server/Fluentbit Events")
+        pipeline = fluentbit_pipeline
+    elif type == 'osquery':
+        dataset_id = search_dataset_id(bearer_token, "Server/OSQuery Events")
+        pipeline = osquery_pipeline
+    elif type == 'telegraf':
+        dataset_id = search_dataset_id(bearer_token, "Server/Telegraf Events")
+        pipeline = telegraf_pipeline
+    else:
+        raise ValueError
+
+    query = query_dataset(bearer_token, dataset_id, pipeline)
+    return is_instance_present(instance_id, query)
+
+
+
+if __name__ == '__main__':
+    validate_in_observe(instance_id="i-06b1cb51220183ce6", type='fluentbit')
+    validate_in_observe(instance_id="i-06b1cb51220183ce6", type='osquery')
+    validate_in_observe(instance_id="i-06b1cb51220183ce6", type='telegraf')
+    pass

--- a/test_code/python_scripts/workflow_tasks.py
+++ b/test_code/python_scripts/workflow_tasks.py
@@ -124,6 +124,8 @@ def config_ini(
     custid="",
     domain="",
     token="",
+    user_email="none",
+    user_password="none",
     config_file_path="config.ini",
     config_file_env="target-stage-tenant",
 ):
@@ -134,6 +136,8 @@ def config_ini(
                 customer_id = {custid}
                 domain = {domain}
                 datastream_token = {token}
+                user_email = {user_email}
+                user_password = {user_password}
             """
         )
 


### PR DESCRIPTION
**Description:**
- Adds `validate_observe.py` as basis to test VMs <> Observe Data flow (See OPAL pipeline to see what is returned from OPAL query)
- Updates to support `user_email` and `user_password` as secrets for Validations 
- Adds more detail to outputs of terraform output
- Updates AWS, GCP, Azure workflows

Tickets:
https://observe.atlassian.net/browse/CON-1396
https://observe.atlassian.net/browse/CON-1754

**Testing:**
See screenshot:
- The data below is returned per cloud vendor and we verify whether in OSquery, FluentBit, Telegraf data exists in Observe for a given instance ID 
<img width="1199" alt="Screenshot 2023-08-11 at 11 53 33 AM" src="https://github.com/observeinc/linux-host-configuration-scripts/assets/124205220/4fe6bfdb-0a46-4031-b8e5-604ebf4d3570">

**See readme.MD for additions** 
AWS:
https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/5826003822
Azure:
https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/5835421046
GCP
https://github.com/observeinc/linux-host-configuration-scripts/actions/runs/5835847192

Example: `telegraf_in_observe` PASS means data is flowing in this machine to Observe as OPAL query was successful and contains its ID
<img width="452" alt="Screenshot 2023-08-11 at 11 58 34 AM" src="https://github.com/observeinc/linux-host-configuration-scripts/assets/124205220/6d489aae-446b-4ae6-b3c0-96ef4a6361b1">



**Reference:**
https://docs.google.com/presentation/d/18IYYONWKNy56UW8vBozRxm8j6oejNYepH8uPEfivrpg/edit?usp=sharing