### PR TITLE
fix: trim procstat default fields

### DIFF
--- a/config_files/telegraf.conf
+++ b/config_files/telegraf.conf
@@ -55,6 +55,15 @@
   interval = "60s"
   period = "60s"
   cmdline_tag = true
+  fieldpass = [
+    "pid", 
+    "num_threads", 
+    "pgrep_serviceprocess_memory_usage", 
+    "pgrep_serviceprocess_memory_swap", 
+    "pgrep_serviceprocess_cpu_usage",
+    "pgrep_serviceprocess_num_threads", 
+    "cmdline"
+    ]
 # Uncomment below metatags if using AWS EC2
 #REPLACE_WITH_OBSERVE_EC2_OPTION[[processors.aws_ec2]]
 #REPLACE_WITH_OBSERVE_EC2_OPTION imds_tags = [ "accountId", "instanceId"]

--- a/test_code/AWS_MACHINES/variables.tf
+++ b/test_code/AWS_MACHINES/variables.tf
@@ -138,7 +138,7 @@ variable "AWS_MACHINE_CONFIGS" {
 
     WINDOWS_SERVER_2016_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-0d7c5eb6a3508d55c"
+      ami_id            = "ami-0e87182c1094f2344"
       ami_description   = "Microsoft Windows Server 2016 with Desktop Experience Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120
@@ -147,7 +147,7 @@ variable "AWS_MACHINE_CONFIGS" {
 
     WINDOWS_SERVER_2019_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-05ca24eaec19902c1"
+      ami_id            = "ami-01dc5695dfebe46cc"
       ami_description   = "Microsoft Windows Server 2019 with Desktop Experience Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120
@@ -156,7 +156,7 @@ variable "AWS_MACHINE_CONFIGS" {
 
     WINDOWS_SERVER_2022_BASE = {
       ami_instance_type = "t3.small"
-      ami_id            = "ami-06810ab448caa0133"
+      ami_id            = "ami-091f300417a06d788"
       ami_description   = "Microsoft Windows Server 2022 Full Locale English AMI provided by Amazon"
       default_user      = "Administrator"
       sleep             = 120


### PR DESCRIPTION
Telegraf has 60+ metrics per process that it ships.  The content goes out of it's way to exclude the metrics that aren't included in this PR so we should only be shipping what actually ends up being used.