### PR TITLE
fix: CS-479 add db so fluent will not rediscover file

### DIFF
--- a/config_files/observe-installer.conf
+++ b/config_files/observe-installer.conf
@@ -4,6 +4,7 @@
     Path_Key filename
     path /tmp/observe-install.log
     Read_from_Head true
+    db    observe-install.db
     Alias observe-install
 [OUTPUT]
     name        http


### PR DESCRIPTION
Ad db for observe-install.log

tested with fluent container - when db line present it never rediscovers file - when not present it rediscovers on any restart