### PR TITLE
fix: Update Jenkins Fluent-bit for capture hostname.

### DIFF
--- a/config_files/observe-jenkins.conf
+++ b/config_files/observe-jenkins.conf
@@ -28,6 +28,13 @@
     Match jenkins*
     call append_tag
     code function append_tag(tag, timestamp, record) new_record = record new_record["_tag"] = tag return 1, timestamp, new_record end
+[FILTER]
+    Name record_modifier
+    Match *
+    Record host ${HOSTNAME}
+    Record datacenter REPLACE_WITH_DATACENTER
+    Record obs_ver 20230412
+    Remove_key _MACHINE_ID
 [OUTPUT]
     name        http
     match       jenkins*


### PR DESCRIPTION
Update to `observe-jenkins.conf` to capture `host` and `datacenter` for Jenkins installation. 

Fix will ensure Jenkins `Agents` and `Builds` resources are populated as the datasets require `primary_key(jobName, buildNum, host, datacenter)`.



